### PR TITLE
Add architecture docs and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,101 +1,79 @@
 # MAPLE: Multi-Agent Protocol Learning Environment
 
-MAPLE is a decentralized, scalable platform for creating, registering, and evolving AI agents. Built with Rust for performance and Python for flexibility, it powers a global ecosystem of self-governing agents via the MAP Protocol, Universal Agent Language (UAL), and Maple Agent Learning Lab (MALL).
+MAPLE is a collection of Rust crates (with optional Python bindings) for building distributed networks of AI agents. Agents communicate through the MAP protocol, exchange structured messages using UAL and can evolve in the Maple Agent Learning Lab (MALL). The project aims to provide a scalable, decentralized platform for autonomous systems.
 
-## Copyright
-© 2025 Finalverse Inc. All rights reserved.
+## Repository Layout
 
-## Contact
-- Email: maple@finalverse.com
-- Website: https://mapleai.org
-- GitHub: https://github.com/finalverse/mapleai.git
+- `agents/` – Core agent implementation and utilities for handling `.map` DNA files.
+- `api/` – REST API with JWT authentication for spawning and managing agents.
+- `cli/` – Command line interface built with `clap`.
+- `core/` – Governance logic and language model integration.
+- `map/` – P2P communication layer using `libp2p`.
+- `mall/` – Agent learning lab with optional Python agents.
+- `mrs/` – Registry Service for DIDs and agent metadata.
+- `runtime/` – Node runtime supporting distributed or enterprise modes.
+- `sdk/` – Rust/Python SDK for developers.
+- `storage/` – MapleDB, PostgreSQL and vector DB crates.
+- `ual/` – Universal Agent Language message format.
 
-## High-Level Components
-- **core/**: Governance and Maple Core LLM/AGI.
-- **map/**: P2P messaging protocol (MAP).
-- **mrs/**: Registry for agent DIDs and "DNA."
-- **ual/**: Multi-mode communication language (JSON, gRPC, byte-level).
-- **mall/**: Learning environment for agent evolution.
-- **agents/**: Pre-built and custom agent implementations.
-- **storage/**: Data backends (MapleDB, PostgreSQL, VectorDB).
-- **sdk/**: Tools for developers to build agents.
-- **api/**: External REST/gRPC interfaces.
-- **runtime/**: Distributed and enterprise node runtime.
-- **cli/**: Command-line interface for MAPLE.
+See `docs/architecture.md` for a detailed overview of how these pieces connect.
 
-## Getting Started
-1. Clone the repo: `git clone https://github.com/finalverse/maple.git`
-2. Build: `cargo build --release`
-3. Run CLI: `cargo run --bin maple -- --help`
+## Quick Start
 
-## Sample Usage Scenarios
-
-### For Developers
-#### 1. Create and Register a Custom Agent
 ```bash
-# Define agents "DNA" (config + LLM weights)
-maple agents create --name "logistics-bot" --config logistics.json --llm mistral-7b
+# build the entire workspace
+cargo build --release
 
-# Register with MRS
-maple mrs register --agents "logistics-bot" --output did:maple:agents:1234
+# run the CLI
+cargo run --bin maple -- --help
 ```
-Build a logistics optimization agent, register it globally, and share it with the Mapleverse.
 
-#### 2. Train an Agent in the Learning Lab
+### Spawning an Agent
+
 ```bash
-# Start MALL sandbox
-maple mall start --task "supply-chain-optimization"
+# create an agent and dump its DNA
+maple agent create --name "logistics-bot" --role "logistics"
 
-# Train agents
-maple mall train --agents "logistics-bot" --iterations 1000
+# register with the registry service
+maple mrs register --name "logistics-bot"
+
+# start a local runtime and spawn the agent
+maple runtime start --mode distributed --nodes 1
+maple runtime spawn --did "did:maple:agent:1234"
 ```
-Evolve your agent’s capabilities in a simulated environment, then publish updates via MRS.
 
-### For Businesses
-#### 3. Deploy a Distributed Supply Chain Network
-```bash
-# Launch distributed runtime
-maple runtime start --mode distributed --nodes 10
+### Using the SDK
 
-# Spawn registered agents
-maple runtime spawn --did did:maple:agents:1234 --count 5
-```
-Run a decentralized network of logistics agents to streamline supply chain operations.
-
-#### 4. Integrate with Enterprise Systems
-```bash
-# Start enterprise runtime
-maple runtime start --mode enterprise --config enterprise.toml
-
-# Query via API
-curl -X GET "http://localhost:8080/agents/status" -H "Authorization: Bearer token"
-```
-Monitor and manage agents via REST API in a secure enterprise setup.
-
-### For Researchers
-#### 5. Experiment with UAL Communication
 ```rust
-use maple::ual::{Message, Mode};
+use maple_sdk::{MapleSdk, SdkConfig};
 
-let msg = Message::new("move", Mode::Json)
-    .with_payload(r#"{"x": 10, "y": 20}"#);
-agent.send(msg);
+let config = SdkConfig {
+    api_url: "http://localhost:8080".to_string(),
+    api_key: "test-key".to_string(),
+    map_listen_addr: "/ip4/0.0.0.0/tcp/0".to_string(),
+    db_path: "maple_sdk_db".to_string(),
+};
+let sdk = MapleSdk::new(config).await.unwrap();
+let did = sdk.create_agent("logistics-bot", "logistics").await.unwrap();
 ```
-Test agent communication in JSON mode, then switch to byte-level for optimization.
 
-## Why MAPLE?
-- **Decentralized:** No central authority—agents self-govern via MAP and MRS.
-- **Scalable:** From edge devices to enterprise clusters.
-- **Evolving:** Agents learn and adapt in MALL.
-- **Developer-Friendly:** SDK and CLI accelerate adoption.
+## Documentation
+
+Additional documents can be found in the `docs/` directory:
+
+- `architecture.md` – overview of the system design.
+- `MAP.md` – details of the MAP peer-to-peer protocol.
+- `AUL.md` – specification of the Universal Agent Language.
+- `TODO.md` – planned improvements.
 
 ## Contributing
-Fork, branch, and submit PRs! Join our Discord for discussions.
+
+Pull requests are welcome! Feel free to open issues or propose new agents and integrations.
 
 ## Contact
-- **Email:** maple@finalverse.com
-- **Website:** https://mapleai.org
-- **GitHub:** https://github.com/finalverse/mapleai.git
 
-## License
+- Email: [maple@finalverse.com](mailto:maple@finalverse.com)
+- Website: <https://mapleai.org>
+- GitHub: <https://github.com/finalverse/mapleai.git>
+
 © 2025 Finalverse Inc. All rights reserved.

--- a/docs/AUL.md
+++ b/docs/AUL.md
@@ -1,0 +1,28 @@
+# Universal Agent Language (UAL)
+
+UAL defines a common message format for communication between MAPLE agents and services. It lives in the `ual` crate and currently supports three modes.
+
+## Modes
+
+- **Json** – Payload is encoded as JSON. Useful for quick prototyping and interoperability.
+- **Grpc** – Structured binary format built with `prost` (not yet implemented).
+- **ByteLevel** – Raw byte payload for maximum efficiency or custom encodings.
+
+Each `UalMessage` contains an action string (e.g., `"move"`) and a payload. Encoding and decoding helpers ensure the payload matches the selected mode.
+
+```rust
+use maple_ual::{UalMessage, Mode};
+
+let msg = UalMessage::new("move", Mode::Json)
+    .with_json_payload(&serde_json::json!({"x": 10, "y": 20}))?;
+let payload: serde_json::Value = msg.decode()?;
+```
+
+## Design Goals
+
+1. **Flexibility** – Support multiple encoding schemes so agents written in different languages can interoperate.
+2. **Transport Agnostic** – UAL messages can be sent over MAP, HTTP, gRPC or embedded in `.map` files.
+3. **Extensibility** – Additional modes (e.g., Cap'n Proto) can be added without breaking existing agents.
+
+Future development will implement full gRPC mode and richer schemas for complex agent interactions.
+

--- a/docs/MAP.md
+++ b/docs/MAP.md
@@ -1,0 +1,26 @@
+# MAP Protocol
+
+The Multi-Agent Protocol (MAP) provides decentralized peer-to-peer communication between MAPLE nodes. It is implemented in the `map` crate using [`libp2p`](https://libp2p.io) and supports discovery and message broadcast.
+
+## Features
+
+- **Peer Discovery** – Uses mDNS so nodes on a local network can automatically find each other.
+- **Encrypted Transport** – Connections use the `noise` protocol for authentication and encryption.
+- **Multiplexing** – The `yamux` multiplexer allows multiple logical streams over a single TCP connection.
+- **Command Channel** – Internally a Tokio `mpsc` channel drives the swarm event loop.
+- **Broadcast Support** – Nodes can broadcast text or raw `.map` files to all peers.
+
+## Example
+
+```rust
+use maple_map::{MapConfig, MapProtocol};
+
+let config = MapConfig { listen_addr: "/ip4/0.0.0.0/tcp/0".to_string() };
+let map = MapProtocol::new(config).await.unwrap();
+map.broadcast("Hello, Mapleverse!".to_string()).await.unwrap();
+```
+
+## Extending
+
+The current implementation prints events to stdout and leaves message routing as a TODO. Future work can integrate gossip protocols, persistent peer stores and custom message types for higher level services such as the Registry Service.
+

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,13 @@
+# TODO: Making MAPLE the Best AI Agent Framework
+
+- [ ] **Implement gRPC support in UAL** – complete encoding/decoding for efficient binary communication.
+- [ ] **Finish message routing in MAP** – send and receive peer messages rather than printing to stdout.
+- [ ] **Persistent storage for MRS** – use MapleDB or PostgreSQL to store registered agents and DIDs.
+- [ ] **Real LLM integrations** – connect `maple-llm` to engines like Llama.cpp or Mistral for generation.
+- [ ] **DID resolution service** – map DIDs to peer IDs and network addresses.
+- [ ] **Vector database backend** – plug `maple-vectordb` into Qdrant/Milvus for similarity search.
+- [ ] **Runtime enhancements** – scaling across clusters, authorization, and graceful shutdown.
+- [ ] **Extensive tests and benchmarks** – ensure reliability and measure performance across crates.
+- [ ] **Documentation website** – publish the content of `docs/` with examples and tutorials.
+- [ ] **Community contributions** – gather feedback and accept external agents or plugins.
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,47 @@
+# MAPLE Architecture
+
+MAPLE (Multi-Agent Protocol Learning Environment) is organized as a set of Rust crates forming a workspace. The platform enables creation, registration and evolution of AI agents that communicate over a peer-to-peer network. Major layers include networking, registry, storage, runtime and developer tooling.
+
+## Workspace Layout
+
+- **agents/** – Agent implementations with utilities to dump and spawn `.map` DNA files.
+- **api/** – REST API exposing runtime capabilities with JWT based authentication.
+- **cli/** – Command line interface built with `clap` for local interaction.
+- **config/** – Common configuration types.
+- **core/** – Governance and language models. Contains an internal Maple LLM and adapters for external models.
+- **mall/** – Maple Agent Learning Lab for agent evolution. Includes `mpy/` for Python based agents.
+- **map/** – MAP protocol built on `libp2p` for decentralized messaging.
+- **mrs/** – MAPLE Registry Service managing agent DIDs and metadata.
+- **runtime/** – Node runtime managing agents and networking (distributed or enterprise modes).
+- **sdk/** – Rust and Python SDKs for integrating MAPLE into other projects.
+- **storage/** – Data backends (MapleDB key-value store, PostgreSQL, Vector DB placeholder).
+- **ual/** – Universal Agent Language used by agents for communication.
+- **utils/** – Workspace utilities and helpers.
+
+## Data Flow
+
+1. **Agent Creation** – Agents are defined in `agents/` with a configuration and optional state. They can dump their data into a `.map` DNA file for portability.
+2. **Registration (MRS)** – The `.map` files or agent configs are registered with the Registry Service (`mrs/`). Agents receive a decentralized identifier (DID) for lookup.
+3. **Network (MAP)** – Nodes communicate via the MAP protocol (`map/`). It uses libp2p with mDNS discovery, noise encryption and yamux multiplexing. Messages or entire `.map` files can be broadcast.
+4. **Runtime** – A runtime instance (`runtime/`) coordinates agents, the registry and storage. It uses MapleDB and optionally PostgreSQL or a vector database for persistence. Agents can be spawned from DIDs or `.map` files and interact over MAP.
+5. **Learning (MALL)** – The learning lab (`mall/`) runs simulations or tasks where agents, including Python agents via `mpy/`, are trained using UAL messages.
+6. **API & CLI** – The REST API (`api/`) exposes runtime functions such as spawning agents. The CLI (`cli/`) provides local commands for developers. Both rely on the SDK crate.
+7. **SDK** – `sdk/` provides a programmatic interface in Rust and Python, wrapping MAP, MRS, and runtime interactions.
+
+## Storage
+
+- **MapleDB** (`storage/mapledb`) – Embedded key-value store backed by `sled` for agent state and metadata.
+- **PostgreSQL** (`storage/pg`) – Structured storage for agent data using `sqlx` (requires external database).
+- **VectorDB** (`storage/vectordb`) – Placeholder integration for vector databases (e.g., Qdrant) used for embeddings or memory retrieval.
+
+## Core LLMs
+
+The `core/` crate groups language model logic.
+
+- **maple/llm/** – External LLM integration with a simple `generate` function (currently a stub). Designed to connect to systems like Llama.cpp or Mistral.
+- **maple/maple/** – Internal Maple language model for governance and conflict resolution among agents.
+
+## Extensibility
+
+The workspace design allows new crates to be added easily. Each crate exposes a clear API and tests. Developers can build custom agents, integrate new storage backends or extend the runtime.
+


### PR DESCRIPTION
## Summary
- add new documentation under `docs/`
- create architecture.md, MAP.md, AUL.md and a TODO checklist
- refresh README with links to docs and quick usage examples

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854293e75408332b401b147e426acad